### PR TITLE
Fix native image auth: password4j runtime init and JWT error logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ bootBuildImage {
     createdDate = "now"
     environment = [
         "BP_JVM_VERSION": "25",
-        "BP_NATIVE_IMAGE_BUILD_ARGUMENTS": "-H:+AddAllCharsets"
+        "BP_NATIVE_IMAGE_BUILD_ARGUMENTS": "-H:+AddAllCharsets --initialize-at-run-time=com.password4j"
     ]
     docker {
         bindHostToBuilder = true

--- a/src/main/java/tech/sledger/config/JwtRequestFilter.java
+++ b/src/main/java/tech/sledger/config/JwtRequestFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -18,6 +19,7 @@ import tech.sledger.service.JwtService;
 import java.io.IOException;
 import java.util.Collection;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class JwtRequestFilter extends OncePerRequestFilter {
@@ -42,6 +44,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 var authToken = new UsernamePasswordAuthenticationToken(user, null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             } catch (Exception e) {
+                log.error("JWT auth error", e);
                 response.setStatus(401);
             }
         }


### PR DESCRIPTION
## Summary
- Add `--initialize-at-run-time=com.password4j` to native image build args to fix Argon2 password verification failing at login in GraalVM native
- Add `log.error` to `JwtRequestFilter` catch block to surface any remaining auth errors instead of silently returning 401

## Test plan
- [ ] Deploy native image and verify login succeeds
- [ ] If login still fails, check logs for the error surfaced by the new logging